### PR TITLE
Bump Corretto version to 25.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM amazoncorretto:21.0.4-alpine as builder
+FROM amazoncorretto:25.0.1-alpine AS builder
 WORKDIR application
 ARG JAR_FILE=target/openleap-config-exec.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
-FROM amazoncorretto:21.0.4-alpine
+FROM amazoncorretto:25.0.1-alpine
 WORKDIR application
 COPY --from=builder application/dependencies/ ./
 COPY --from=builder application/spring-boot-loader/ ./


### PR DESCRIPTION
Update Corretto version from 21.0.4 to 25.0.1 to benefit from latest security patches and performance improvements.